### PR TITLE
feat: support ":" in label identifier

### DIFF
--- a/internal/bql/lexer.go
+++ b/internal/bql/lexer.go
@@ -125,7 +125,7 @@ func (l *Lexer) skipWhitespace() {
 // readIdentifier reads an identifier (letters, digits, underscores, hyphens).
 func (l *Lexer) readIdentifier() string {
 	start := l.pos - 1
-	for isLetter(l.ch) || isDigit(l.ch) || l.ch == '_' || l.ch == '-' {
+	for isLetter(l.ch) || isDigit(l.ch) || l.ch == '_' || l.ch == '-' || l.ch == ':' {
 		l.readChar()
 	}
 	return l.input[start : l.pos-1]

--- a/internal/bql/parser_test.go
+++ b/internal/bql/parser_test.go
@@ -85,6 +85,7 @@ func TestParser_InExpression(t *testing.T) {
 		{"in three values", "status in (open, in_progress, blocked)", "status", false, []string{"open", "in_progress", "blocked"}},
 		{"not in", "label not in (backlog, deferred)", "label", true, []string{"backlog", "deferred"}},
 		{"in single value", "type in (bug)", "type", false, []string{"bug"}},
+		{"in values with colons", "label in (spec:010-output-schema-support)", "label", false, []string{"spec:010-output-schema-support"}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add support for ':' in label identifier

## Related Issues

Closes #5

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated documentation as needed
- [ ] I have updated golden files if UI changed (`make test-update`)

## NOTE: Running `make test-update` fails:

```
Updating golden files in packages with teatest...
# ./internal/ui/bqlinput/...
pattern ./internal/ui/bqlinput/...: lstat ./internal/ui/bqlinput/: no such file or directory
FAIL    ./internal/ui/bqlinput/... [setup failed]
# ./internal/ui/colorpicker/...
..
```