### PR TITLE
fix: detailsview tree sync

### DIFF
--- a/internal/mode/search/search.go
+++ b/internal/mode/search/search.go
@@ -1431,11 +1431,13 @@ func (m Model) navigateToDependency(issueID string) (Model, tea.Cmd) {
 	m.hasDetail = true
 
 	// Try to find and select this issue in the results list
-	for i, result := range m.results {
-		if result.ID == issueID {
-			m.selectedIdx = i
-			m.resultsList.Select(i)
-			break
+	if m.subMode == mode.SubModeList {
+		for i, result := range m.results {
+			if result.ID == issueID {
+				m.selectedIdx = i
+				m.resultsList.Select(i)
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
When navigateToDependency also move the cursor in the tree

closes #14

Demonstration https://www.loom.com/share/d162055d1eb241998c2f91e74ec6c6c5