### PR TITLE
fix: add Windows support for process termination

### DIFF
--- a/internal/orchestration/v2/handler/kill_process_unix.go
+++ b/internal/orchestration/v2/handler/kill_process_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package handler
+
+import "syscall"
+
+// killProcess forcefully terminates a process by PID using SIGKILL.
+// This is the Unix implementation.
+func killProcess(pid int) error {
+	return syscall.Kill(pid, syscall.SIGKILL)
+}

--- a/internal/orchestration/v2/handler/kill_process_windows.go
+++ b/internal/orchestration/v2/handler/kill_process_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package handler
+
+import "os"
+
+// killProcess forcefully terminates a process by PID.
+// This is the Windows implementation using os.Process.Kill()
+// which calls TerminateProcess on Windows.
+func killProcess(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return proc.Kill()
+}


### PR DESCRIPTION
## Description

Replace Unix-specific `syscall.Kill` with platform-specific `killProcess` helper that uses SIGKILL on Unix and TerminateProcess on Windows. This fixes compilation failure on Windows.

**Changes:**
- Added `kill_process_unix.go` with `//go:build !windows` tag using `syscall.Kill(pid, syscall.SIGKILL)`
- Added `kill_process_windows.go` with `//go:build windows` tag using `os.FindProcess(pid).Kill()`
- Modified `stop_process.go` to remove `syscall` import and call the new `killProcess(pid)` helper

## Related Issues

Closes #22

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated documentation as needed
- [ ] I have updated golden files if UI changed (`make test-update`)

## Screenshots (if applicable)

N/A - no UI changes.

## Testing Notes

1. Build on Unix/Linux/macOS should continue to work as before
2. Build on Windows (`go build` or `go install`) should now succeed instead of failing with `undefined: syscall.Kill`
3. All existing handler tests pass (200+ tests in `./internal/orchestration/v2/handler/...`)
4. Run `go vet ./internal/orchestration/v2/handler/...` to verify no issues

**Note:** Full Windows testing requires a Windows environment. The fix uses `os.Process.Kill()` which is the standard cross-platform approach in Go for forceful process termination.
