### PR TITLE
feat(clipboard): add OSC 52 support for remote/tmux sessions

### DIFF
--- a/internal/mode/shared/clipboard.go
+++ b/internal/mode/shared/clipboard.go
@@ -2,6 +2,9 @@
 package shared
 
 import (
+	"encoding/base64"
+	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 )
@@ -13,10 +16,77 @@ type Clipboard interface {
 }
 
 // SystemClipboard implements Clipboard using the system clipboard.
+// It auto-detects remote/tmux sessions and uses OSC 52 escape sequences
+// when appropriate, falling back to native clipboard tools otherwise.
 type SystemClipboard struct{}
 
 // Copy copies text to the system clipboard.
+// In remote sessions (SSH) or terminal multiplexers (tmux, screen),
+// it uses OSC 52 escape sequences. Otherwise, it uses native tools
+// like pbcopy (macOS) or xclip (Linux).
 func (SystemClipboard) Copy(text string) error {
+	if shouldUseOSC52() {
+		return copyViaOSC52(text)
+	}
+	return copyViaNative(text)
+}
+
+// shouldUseOSC52 returns true if we should use OSC 52 escape sequences
+// instead of native clipboard tools. This is the case when running in
+// a remote session (SSH) or terminal multiplexer (tmux, screen).
+func shouldUseOSC52() bool {
+	// Check for SSH session
+	if os.Getenv("SSH_TTY") != "" ||
+		os.Getenv("SSH_CLIENT") != "" ||
+		os.Getenv("SSH_CONNECTION") != "" {
+		return true
+	}
+	// Check for tmux
+	if os.Getenv("TMUX") != "" {
+		return true
+	}
+	// Check for GNU screen
+	if os.Getenv("STY") != "" {
+		return true
+	}
+	return false
+}
+
+// copyViaOSC52 copies text using OSC 52 escape sequences.
+// When inside tmux, it wraps the sequence in a DCS passthrough.
+func copyViaOSC52(text string) (err error) {
+	encoded := base64.StdEncoding.EncodeToString([]byte(text))
+
+	var seq string
+	if os.Getenv("TMUX") != "" {
+		// tmux passthrough: wrap OSC 52 in DCS sequence
+		// \x1bP starts DCS, tmux; identifies passthrough
+		// Inner \x1b is doubled to \x1b\x1b
+		// \x1b\\ ends DCS
+		seq = fmt.Sprintf("\x1bPtmux;\x1b\x1b]52;c;%s\x07\x1b\\", encoded)
+	} else {
+		// Direct OSC 52
+		seq = fmt.Sprintf("\x1b]52;c;%s\x07", encoded)
+	}
+
+	// Write to /dev/tty to bypass any stdout redirection
+	// and work correctly with Bubble Tea's alt-screen mode
+	tty, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open /dev/tty: %w", err)
+	}
+	defer func() {
+		if closeErr := tty.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	_, err = tty.WriteString(seq)
+	return err
+}
+
+// copyViaNative copies text using native clipboard tools.
+func copyViaNative(text string) error {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":

--- a/internal/mode/shared/clipboard_test.go
+++ b/internal/mode/shared/clipboard_test.go
@@ -1,0 +1,129 @@
+package shared
+
+import (
+	"encoding/base64"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldUseOSC52(t *testing.T) {
+	// Helper to clear all relevant env vars
+	clearEnv := func() {
+		os.Unsetenv("SSH_TTY")
+		os.Unsetenv("SSH_CLIENT")
+		os.Unsetenv("SSH_CONNECTION")
+		os.Unsetenv("TMUX")
+		os.Unsetenv("STY")
+	}
+
+	tests := []struct {
+		name     string
+		envVars  map[string]string
+		expected bool
+	}{
+		{
+			name:     "no env vars set",
+			envVars:  map[string]string{},
+			expected: false,
+		},
+		{
+			name:     "SSH_TTY set",
+			envVars:  map[string]string{"SSH_TTY": "/dev/pts/0"},
+			expected: true,
+		},
+		{
+			name:     "SSH_CLIENT set",
+			envVars:  map[string]string{"SSH_CLIENT": "192.168.1.1 12345 22"},
+			expected: true,
+		},
+		{
+			name:     "SSH_CONNECTION set",
+			envVars:  map[string]string{"SSH_CONNECTION": "192.168.1.1 12345 192.168.1.2 22"},
+			expected: true,
+		},
+		{
+			name:     "TMUX set",
+			envVars:  map[string]string{"TMUX": "/tmp/tmux-1000/default,12345,0"},
+			expected: true,
+		},
+		{
+			name:     "STY set (GNU screen)",
+			envVars:  map[string]string{"STY": "12345.pts-0.hostname"},
+			expected: true,
+		},
+		{
+			name:     "SSH and TMUX both set",
+			envVars:  map[string]string{"SSH_TTY": "/dev/pts/0", "TMUX": "/tmp/tmux"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearEnv()
+			for k, v := range tt.envVars {
+				os.Setenv(k, v)
+			}
+			t.Cleanup(clearEnv)
+
+			result := shouldUseOSC52()
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestOSC52SequenceFormat(t *testing.T) {
+	// Test that base64 encoding is correct
+	text := "ISSUE-123"
+	encoded := base64.StdEncoding.EncodeToString([]byte(text))
+	require.Equal(t, "SVNTVUUtMTIz", encoded)
+
+	// Verify the expected OSC 52 sequence format
+	expectedDirect := "\x1b]52;c;SVNTVUUtMTIz\x07"
+	directSeq := "\x1b]52;c;" + encoded + "\x07"
+	require.Equal(t, expectedDirect, directSeq)
+
+	// Verify the expected tmux passthrough format
+	expectedTmux := "\x1bPtmux;\x1b\x1b]52;c;SVNTVUUtMTIz\x07\x1b\\"
+	tmuxSeq := "\x1bPtmux;\x1b\x1b]52;c;" + encoded + "\x07\x1b\\"
+	require.Equal(t, expectedTmux, tmuxSeq)
+}
+
+func TestOSC52SequenceWithSpecialChars(t *testing.T) {
+	// Test that special characters are properly base64 encoded
+	tests := []struct {
+		name    string
+		text    string
+		encoded string
+	}{
+		{
+			name:    "simple text",
+			text:    "hello",
+			encoded: "aGVsbG8=",
+		},
+		{
+			name:    "with spaces",
+			text:    "hello world",
+			encoded: "aGVsbG8gd29ybGQ=",
+		},
+		{
+			name:    "with newlines",
+			text:    "line1\nline2",
+			encoded: "bGluZTEKbGluZTI=",
+		},
+		{
+			name:    "unicode",
+			text:    "hello 世界",
+			encoded: "aGVsbG8g5LiW55WM",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded := base64.StdEncoding.EncodeToString([]byte(tt.text))
+			require.Equal(t, tt.encoded, encoded)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Auto-detect SSH and terminal multiplexer sessions (tmux, screen) and use OSC 52 escape sequences instead of native clipboard tools. This allows clipboard operations to work through SSH and nested tmux by passing the escape sequence to the user's local terminal emulator.

## Related Issues

Closes #(issue number)

#25 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [ ] I have updated documentation as needed
- [ ] I have updated golden files if UI changed (`make test-update`)

## Screenshots (if applicable)

Add screenshots for UI changes.

## Testing Notes

Describe how reviewers can test these changes.

Run perles on a remote host, under tmux and make sure copy id works
