### PR TITLE
fix(config): respect BEADS_DIR env var priority over config file

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -88,15 +88,16 @@ func runDaemon(_ *cobra.Command, _ []string) error {
 	}
 
 	// Resolution priority for beads directory (same as TUI):
-	// 1. -b flag (already in cfg.BeadsDir via viper binding)
-	// 2. BEADS_DIR environment variable
-	// 3. beads_dir config file setting (already in cfg.BeadsDir)
-	// 4. Current working directory
-	dbPath := cfg.BeadsDir
-	if dbPath == "" {
-		dbPath = os.Getenv("BEADS_DIR")
-	}
-	if dbPath == "" {
+	// 1. BEADS_DIR environment variable
+	// 2. beads_dir config file setting
+	// 3. Current working directory
+	// Note: daemon doesn't have -b flag; use root command for explicit path
+	var dbPath string
+	if envDir := os.Getenv("BEADS_DIR"); envDir != "" {
+		dbPath = envDir
+	} else if cfg.BeadsDir != "" {
+		dbPath = cfg.BeadsDir
+	} else {
 		dbPath = workDir
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -174,15 +174,22 @@ func runApp(cmd *cobra.Command, args []string) error {
 	}
 
 	// Resolution priority for beads directory:
-	// 1. -b flag (already in cfg.BeadsDir via viper binding)
+	// 1. -b flag (explicitly provided on command line)
 	// 2. BEADS_DIR environment variable
-	// 3. beads_dir config file setting (already in cfg.BeadsDir)
+	// 3. beads_dir config file setting
 	// 4. Current working directory
-	dbPath := cfg.BeadsDir
-	if dbPath == "" {
-		dbPath = os.Getenv("BEADS_DIR")
-	}
-	if dbPath == "" {
+	var dbPath string
+	if cmd.Flags().Changed("beads-dir") {
+		// -b flag explicitly provided on command line
+		dbPath, _ = cmd.Flags().GetString("beads-dir")
+	} else if envDir := os.Getenv("BEADS_DIR"); envDir != "" {
+		// BEADS_DIR environment variable
+		dbPath = envDir
+	} else if cfg.BeadsDir != "" {
+		// beads_dir from config file
+		dbPath = cfg.BeadsDir
+	} else {
+		// Default to working directory
 		dbPath = workDir
 	}
 


### PR DESCRIPTION
## Summary

- Fix BEADS_DIR environment variable being ignored when beads_dir is set in config file
- Add support for BEADS_DIR pointing directly to a directory containing beads.db (centralized beads databases)

## Changes

- **cmd/root.go**: Explicitly check -b flag first, then BEADS_DIR env var, then config file setting, then working directory
- **cmd/daemon.go**: Check BEADS_DIR env var before config file setting  
- **internal/paths/beads.go**: Detect directories containing beads.db directly, supporting centralized beads databases without .beads subdirectory

## Test plan

- [x] All existing tests pass
- [ ] Test with `BEADS_DIR=/path/to/beads-db perles` where the path contains beads.db directly
- [ ] Test with `-b` flag still takes priority over BEADS_DIR
- [ ] Test config file beads_dir still works when BEADS_DIR is not set