### PR TITLE
fix(kanban): preserve selected issue when returning from search and during async reloads

### DIFF
--- a/internal/mode/kanban/handlers.go
+++ b/internal/mode/kanban/handlers.go
@@ -73,7 +73,7 @@ func (m Model) handleBoardKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case key.Matches(msg, keys.Kanban.Refresh):
 		// Save cursor before refresh to restore position after
 		m.pendingCursor = m.saveCursor()
-		m.loading = true
+		m.startReloadCycle()
 		m.manualRefreshed = true
 		m.autoRefreshed = false
 		// Invalidate other views so they reload when switched to
@@ -482,22 +482,26 @@ func (m Model) handleRenameViewModalKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	return m, cmd
 }
 
-// handleColumnLoaded processes column load completion.
+// handleColumnLoaded processes a column load message for an active reload cycle.
+// We may receive column messages out of order, so cursor restoration cannot assume
+// the selected issue appears in the first loaded column.
 func (m Model) handleColumnLoaded(msg tea.Msg) (Model, tea.Cmd) {
 	// Pass message to board for handling
 	m.board, _ = m.board.Update(msg)
 
-	// SQLite queries are instant, so treat every load message as completion
-	m.loading = false
+	reloadDone := m.completeLoadMsg()
 
 	// Restore cursor if we have a pending state
 	if m.pendingCursor != nil {
-		m = m.restoreCursor(m.pendingCursor)
-		m.pendingCursor = nil
+		var restored bool
+		m, restored = m.restoreCursor(m.pendingCursor)
+		if restored || reloadDone {
+			m.pendingCursor = nil
+		}
 	}
 	// Auto sync is silent, manual refresh shows toaster
 	m.autoRefreshed = false
-	if m.manualRefreshed {
+	if m.manualRefreshed && reloadDone {
 		m.manualRefreshed = false
 		return m, func() tea.Msg { return mode.ShowToastMsg{Message: "refreshed issues", Style: toaster.StyleSuccess} }
 	}
@@ -513,6 +517,7 @@ func (m Model) handleIssueSaved(msg issueSavedMsg) (Model, tea.Cmd) {
 	}
 	m.pendingCursor = m.saveCursor()
 	m.board = m.board.InvalidateViews()
+	m.startReloadCycle()
 	return m, m.board.LoadAllColumns()
 }
 
@@ -557,7 +562,7 @@ func (m Model) HandleDBChanged() (Model, tea.Cmd) {
 
 	// Trigger refresh
 	m.pendingCursor = m.saveCursor()
-	m.loading = true
+	m.startReloadCycle()
 	m.autoRefreshed = true
 	m.manualRefreshed = false
 
@@ -594,7 +599,7 @@ func (m Model) handleColEditorSave(msg coleditor.SaveMsg) (Model, tea.Cmd) {
 	m.rebuildBoard()
 
 	m.view = ViewBoard
-	m.loading = true
+	m.startReloadCycle()
 	cmds := []tea.Cmd{
 		func() tea.Msg { return mode.ShowToastMsg{Message: "Column saved", Style: toaster.StyleSuccess} },
 	}
@@ -627,7 +632,7 @@ func (m Model) handleColEditorDelete(msg coleditor.DeleteMsg) (Model, tea.Cmd) {
 	m.rebuildBoard()
 
 	m.view = ViewBoard
-	m.loading = true
+	m.startReloadCycle()
 	cmds := []tea.Cmd{
 		func() tea.Msg { return mode.ShowToastMsg{Message: "Column deleted", Style: toaster.StyleSuccess} },
 	}
@@ -671,7 +676,7 @@ func (m Model) handleColEditorAdd(msg coleditor.AddMsg) (Model, tea.Cmd) {
 	m.rebuildBoardWithFocus(insertPos)
 
 	m.view = ViewBoard
-	m.loading = true
+	m.startReloadCycle()
 	cmds := []tea.Cmd{
 		func() tea.Msg { return mode.ShowToastMsg{Message: "Column added", Style: toaster.StyleSuccess} },
 	}
@@ -769,7 +774,7 @@ func (m Model) handleIssueDeleted(msg issueDeletedMsg) (Model, tea.Cmd) {
 	m.deleteIssueIDs = nil
 	m.selectedIssue = nil
 	m.pendingCursor = nil // Don't try to restore cursor to deleted issue
-	m.loading = true
+	m.startReloadCycle()
 	m.board = m.board.InvalidateViews()
 
 	return m, tea.Batch(

--- a/internal/mode/kanban/kanban.go
+++ b/internal/mode/kanban/kanban.go
@@ -74,7 +74,8 @@ type Model struct {
 	editingIssue *beads.Issue // Issue being edited (for title/description comparison on save)
 
 	// Pending cursor restoration after refresh
-	pendingCursor *cursorState
+	pendingCursor    *cursorState
+	pendingLoadCount int // Remaining expected load messages for current reload cycle
 
 	// Refresh state tracking
 	autoRefreshed   bool // Set when refresh triggered by file watcher
@@ -137,8 +138,11 @@ func (m Model) Refresh() tea.Cmd {
 // RefreshFromConfig rebuilds the board from the current config.
 // Use this when columns have been added/removed externally.
 func (m Model) RefreshFromConfig() (Model, tea.Cmd) {
+	// Preserve current selection so returning from another mode (e.g. search)
+	// keeps the cursor on the same issue after the board reloads.
+	m.pendingCursor = m.saveCursor()
 	m.rebuildBoard()
-	m.loading = true
+	m.startReloadCycle()
 	return m, m.loadBoardCmd()
 }
 
@@ -183,7 +187,16 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case board.TreeColumnLoadedMsg:
 		// Delegate tree column load messages to board
 		m.board, _ = m.board.Update(msg)
-		m.loading = false
+		reloadDone := m.completeLoadMsg()
+		if m.pendingCursor != nil && reloadDone {
+			// Tree columns don't support SelectByID restoration; clear pending at end of cycle.
+			m.pendingCursor = nil
+		}
+		m.autoRefreshed = false
+		if m.manualRefreshed && reloadDone {
+			m.manualRefreshed = false
+			return m, func() tea.Msg { return mode.ShowToastMsg{Message: "refreshed issues", Style: toaster.StyleSuccess} }
+		}
 		return m, nil
 
 	case tea.MouseMsg:
@@ -428,20 +441,22 @@ func (m Model) saveCursor() *cursorState {
 }
 
 // restoreCursor attempts to restore selection to the saved issue.
-func (m Model) restoreCursor(state *cursorState) Model {
+// Returns true when the issue was found and selected.
+func (m Model) restoreCursor(state *cursorState) (Model, bool) {
 	if state == nil {
-		return m
+		return m, false
 	}
 
-	// Try to find the issue by ID (may have moved columns)
+	// Keep focus anchored to the previous column while loads are still arriving.
+	m.board = m.board.SetFocus(state.column)
+
+	// Try to find the issue by ID (it may have moved columns).
 	newBoard, found := m.board.SelectByID(state.issueID)
 	if found {
 		m.board = newBoard
-	} else {
-		// Issue not found, stay in same column
-		m.board = m.board.SetFocus(state.column)
+		return m, true
 	}
-	return m
+	return m, false
 }
 
 // boardHeight returns the available height for the board, accounting for status bar.
@@ -479,6 +494,37 @@ func (m Model) loadBoardCmd() tea.Cmd {
 		return m.board.LoadCurrentViewCmd()
 	}
 	return m.board.LoadAllColumns()
+}
+
+// countPendingLoadMsgs returns the number of load messages expected for the current view.
+func (m Model) countPendingLoadMsgs() int {
+	count := 0
+	viewIndex := m.board.CurrentViewIndex()
+	for i := 0; i < m.board.ColCount(); i++ {
+		col := m.board.BoardColumn(i)
+		if col == nil {
+			continue
+		}
+		if cmd := col.LoadCmd(viewIndex, i); cmd != nil {
+			count++
+		}
+	}
+	return count
+}
+
+// startReloadCycle initializes load-tracking state for a board reload operation.
+func (m *Model) startReloadCycle() {
+	m.pendingLoadCount = m.countPendingLoadMsgs()
+	m.loading = m.pendingLoadCount > 0
+}
+
+// completeLoadMsg advances reload tracking by one message and reports whether reload is complete.
+func (m *Model) completeLoadMsg() bool {
+	if m.pendingLoadCount > 0 {
+		m.pendingLoadCount--
+	}
+	m.loading = m.pendingLoadCount > 0
+	return m.pendingLoadCount == 0
 }
 
 // currentViewIndex returns the current view index, or 0 if no views.

--- a/internal/mode/kanban/kanban_test.go
+++ b/internal/mode/kanban/kanban_test.go
@@ -144,6 +144,39 @@ func createTestModelWithIssue(issueID string, query string) Model {
 	}
 }
 
+// createRefreshTestModel builds a kanban model configured for reload/cursor tests.
+func createRefreshTestModel(t *testing.T, columns []config.ColumnConfig) Model {
+	cfg := config.Defaults()
+	cfg.Views = []config.ViewConfig{{Name: "Test", Columns: columns}}
+	mockExecutor := mocks.NewMockBQLExecutor(t)
+
+	services := mode.Services{
+		Config:   &cfg,
+		Executor: mockExecutor,
+	}
+
+	brd := board.NewFromViews(cfg.GetViews(), mockExecutor, nil).SetSize(100, 40)
+	return Model{
+		services: services,
+		board:    brd,
+		width:    100,
+		height:   40,
+		view:     ViewBoard,
+	}
+}
+
+// seedBoardColumn loads test issues into a board column via a ColumnLoadedMsg.
+func seedBoardColumn(brd board.Model, columnIndex int, columnTitle string, issues []beads.Issue) board.Model {
+	brd, _ = brd.Update(board.ColumnLoadedMsg{
+		ViewIndex:   0,
+		ColumnIndex: columnIndex,
+		ColumnTitle: columnTitle,
+		Issues:      issues,
+		Err:         nil,
+	})
+	return brd
+}
+
 func TestKanban_EnterKey_SendsSubModeTree(t *testing.T) {
 	m := createTestModelWithIssue("test-123", "status = open")
 
@@ -1125,6 +1158,134 @@ func TestKanban_HandleIssueSaved_Success(t *testing.T) {
 
 	require.NotNil(t, m.pendingCursor, "should save cursor for issue following")
 	require.Equal(t, "test-123", m.pendingCursor.issueID, "cursor should track saved issue")
+}
+
+func TestKanban_RefreshFromConfig_PreservesSelectedIssue(t *testing.T) {
+	columns := []config.ColumnConfig{
+		{Name: "In Progress", Query: "status = in_progress", Color: "#888888"},
+	}
+	m := createRefreshTestModel(t, columns)
+
+	issues := []beads.Issue{
+		{ID: "task-1", TitleText: "Task 1", Type: beads.TypeTask},
+		{ID: "task-2", TitleText: "Task 2", Type: beads.TypeTask},
+		{ID: "task-3", TitleText: "Task 3", Type: beads.TypeTask},
+	}
+	m.board = seedBoardColumn(m.board, 0, "In Progress", issues)
+
+	var found bool
+	m.board, found = m.board.SelectByID("task-3")
+	require.True(t, found, "precondition: task-3 should be selectable")
+	require.Equal(t, "task-3", m.board.SelectedIssue().ID, "precondition: task-3 should be selected")
+
+	m, _ = m.RefreshFromConfig()
+	require.NotNil(t, m.pendingCursor, "refresh should capture cursor for restoration")
+	require.Equal(t, "task-3", m.pendingCursor.issueID, "refresh should track selected issue ID")
+
+	// Simulate column reload completion after RefreshFromConfig().
+	m, _ = m.handleColumnLoaded(board.ColumnLoadedMsg{
+		ViewIndex:   0,
+		ColumnIndex: 0,
+		ColumnTitle: "In Progress",
+		Issues:      issues,
+		Err:         nil,
+	})
+
+	selected := m.board.SelectedIssue()
+	require.NotNil(t, selected, "selection should be restored after reload")
+	require.Equal(t, "task-3", selected.ID, "cursor should stay on previously selected issue")
+	require.Nil(t, m.pendingCursor, "pending cursor should clear after restoration")
+}
+
+func TestKanban_RefreshFromConfig_RestoresAfterLaterColumnLoad(t *testing.T) {
+	columns := []config.ColumnConfig{
+		{Name: "Todo", Query: "status = open", Color: "#999999"},
+		{Name: "In Progress", Query: "status = in_progress", Color: "#888888"},
+	}
+	m := createRefreshTestModel(t, columns)
+	col0Issues := []beads.Issue{
+		{ID: "task-1", TitleText: "Task 1", Type: beads.TypeTask},
+	}
+	col1Issues := []beads.Issue{
+		{ID: "task-2", TitleText: "Task 2", Type: beads.TypeTask},
+		{ID: "task-3", TitleText: "Task 3", Type: beads.TypeTask},
+	}
+	m.board = seedBoardColumn(m.board, 0, "Todo", col0Issues)
+	m.board = seedBoardColumn(m.board, 1, "In Progress", col1Issues)
+
+	var found bool
+	m.board, found = m.board.SelectByID("task-3")
+	require.True(t, found, "precondition: task-3 should be selectable")
+	require.Equal(t, "task-3", m.board.SelectedIssue().ID, "precondition: task-3 should be selected")
+
+	m, _ = m.RefreshFromConfig()
+	require.NotNil(t, m.pendingCursor, "refresh should capture cursor for restoration")
+
+	// First loaded column does not contain the selected issue: keep pending cursor.
+	m, _ = m.handleColumnLoaded(board.ColumnLoadedMsg{
+		ViewIndex:   0,
+		ColumnIndex: 0,
+		ColumnTitle: "Todo",
+		Issues:      col0Issues,
+		Err:         nil,
+	})
+	require.NotNil(t, m.pendingCursor, "cursor restore should remain pending until matching issue loads")
+
+	// Later column includes selected issue: restore and clear pending cursor.
+	m, _ = m.handleColumnLoaded(board.ColumnLoadedMsg{
+		ViewIndex:   0,
+		ColumnIndex: 1,
+		ColumnTitle: "In Progress",
+		Issues:      col1Issues,
+		Err:         nil,
+	})
+	selected := m.board.SelectedIssue()
+	require.NotNil(t, selected, "selection should be restored once matching column loads")
+	require.Equal(t, "task-3", selected.ID, "cursor should restore to the original issue")
+	require.Nil(t, m.pendingCursor, "pending cursor should clear after successful restoration")
+}
+
+func TestKanban_RefreshFromConfig_ClearsPendingWhenIssueMissing(t *testing.T) {
+	columns := []config.ColumnConfig{
+		{Name: "Todo", Query: "status = open", Color: "#999999"},
+		{Name: "In Progress", Query: "status = in_progress", Color: "#888888"},
+	}
+	m := createRefreshTestModel(t, columns)
+	initialCol0 := []beads.Issue{{ID: "task-1", TitleText: "Task 1", Type: beads.TypeTask}}
+	initialCol1 := []beads.Issue{
+		{ID: "task-2", TitleText: "Task 2", Type: beads.TypeTask},
+		{ID: "task-3", TitleText: "Task 3", Type: beads.TypeTask},
+	}
+	reloadedCol0 := []beads.Issue{{ID: "task-1", TitleText: "Task 1", Type: beads.TypeTask}}
+	reloadedCol1 := []beads.Issue{{ID: "task-2", TitleText: "Task 2", Type: beads.TypeTask}} // task-3 removed
+
+	m.board = seedBoardColumn(m.board, 0, "Todo", initialCol0)
+	m.board = seedBoardColumn(m.board, 1, "In Progress", initialCol1)
+
+	var found bool
+	m.board, found = m.board.SelectByID("task-3")
+	require.True(t, found, "precondition: task-3 should be selectable")
+
+	m, _ = m.RefreshFromConfig()
+	require.NotNil(t, m.pendingCursor, "refresh should capture cursor for restoration")
+
+	m, _ = m.handleColumnLoaded(board.ColumnLoadedMsg{
+		ViewIndex:   0,
+		ColumnIndex: 0,
+		ColumnTitle: "Todo",
+		Issues:      reloadedCol0,
+		Err:         nil,
+	})
+	require.NotNil(t, m.pendingCursor, "pending cursor should remain before all loads complete")
+
+	m, _ = m.handleColumnLoaded(board.ColumnLoadedMsg{
+		ViewIndex:   0,
+		ColumnIndex: 1,
+		ColumnTitle: "In Progress",
+		Issues:      reloadedCol1,
+		Err:         nil,
+	})
+	require.Nil(t, m.pendingCursor, "pending cursor should clear when issue is missing after full reload")
 }
 
 func TestKanban_HandleIssueSaved_Error(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes Kanban cursor/selection loss when returning from Search and during async column reloads.

### What changed

- Preserve selected Kanban issue before `RefreshFromConfig()` reloads.
- Keep cursor restoration pending across async load messages instead of clearing after the first loaded column.
- Track reload lifecycle explicitly via:
  - `startReloadCycle()`
  - `completeLoadMsg()`
  - `pendingLoadCount`
- Keep behavior consistent across refresh-triggering paths (`refresh`, `db change`, `issue save`, column edit/add/delete, issue delete).
- Add targeted regression tests for:
  - selection preserved after refresh
  - restoration when selected issue appears in a later-loaded column
  - pending cursor cleanup when selected issue no longer exists
- Refactor tests with small shared helpers to reduce boilerplate.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated documentation as needed
- [x] I have updated golden files if UI changed (`make test-update`)

## Screenshots (if applicable)

N/A (no visual UI rendering changes)

## Testing Notes

Automated:
- `go test ./internal/mode/kanban`
- `go test ./...`

Manual:
1. Open Kanban with multiple tasks.
2. Select a non-first task in a column.
3. Press `Enter` to open Search/tree view.
4. Press `Esc` to return to Kanban.
5. Verify selection remains on the same issue.

