### PR TITLE
fix(formmodal): allow j/k to type in non-vim textarea fields

### DIFF
--- a/internal/ui/shared/formmodal/formmodal.go
+++ b/internal/ui/shared/formmodal/formmodal.go
@@ -1391,12 +1391,13 @@ func (m Model) handleKeyForTextArea(msg tea.KeyMsg, fs *fieldState) (Model, tea.
 	}
 
 	// Non-vim textareas should keep text-field-like vertical navigation flow.
+	// Use msg.Type to match only actual arrow keys, not j/k which should type characters.
 	if !fs.config.VimEnabled {
-		if key.Matches(msg, keys.Common.Down) {
+		if msg.Type == tea.KeyDown {
 			m = m.nextField()
 			return m, m.blinkCmd()
 		}
-		if key.Matches(msg, keys.Common.Up) {
+		if msg.Type == tea.KeyUp {
 			m = m.prevField()
 			return m, m.blinkCmd()
 		}

--- a/internal/ui/shared/formmodal/formmodal_test.go
+++ b/internal/ui/shared/formmodal/formmodal_test.go
@@ -2802,6 +2802,51 @@ func TestTextAreaField_SubmitIncludesValue(t *testing.T) {
 	require.Equal(t, "My description", submitMsg.Values["description"])
 }
 
+func TestTextAreaField_JKTypesCharacters_NotNavigate(t *testing.T) {
+	cfg := FormConfig{
+		Title: "Test Form",
+		Fields: []FieldConfig{
+			{Key: "description", Type: FieldTypeTextArea, Label: "Description"},
+			{Key: "name", Type: FieldTypeText, Label: "Name"},
+		},
+	}
+	m := New(cfg)
+	require.Equal(t, 0, m.focusedIndex)
+
+	// Type "project" - contains j which should NOT navigate to the next field
+	for _, r := range "project" {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	require.Equal(t, 0, m.focusedIndex, "j should not navigate away from textarea")
+	require.Equal(t, "project", m.fields[0].textArea.Value())
+
+	// Same for k - type "task"
+	m = New(cfg)
+	for _, r := range "task" {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	require.Equal(t, 0, m.focusedIndex, "k should not navigate away from textarea")
+	require.Equal(t, "task", m.fields[0].textArea.Value())
+}
+
+func TestTextAreaField_ArrowDownNavigatesToNextField(t *testing.T) {
+	cfg := FormConfig{
+		Title: "Test Form",
+		Fields: []FieldConfig{
+			{Key: "description", Type: FieldTypeTextArea, Label: "Description"},
+			{Key: "name", Type: FieldTypeText, Label: "Name"},
+		},
+	}
+	m := New(cfg)
+	require.Equal(t, 0, m.focusedIndex)
+
+	// Arrow down should still navigate (not broken by the fix)
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	require.Equal(t, 1, m.focusedIndex, "arrow down should navigate to next field")
+}
+
 func TestTextAreaField_ForwardsNonKeyMessages(t *testing.T) {
 	cfg := FormConfig{
 		Title: "Test Form",


### PR DESCRIPTION
## Description

In the "New Workflow" modal, pressing `j` or `k` while typing in a textarea argument field (non-vim mode) would navigate to the next/previous field instead of inserting the character. This made it impossible to type words containing `j` or `k` (e.g. "project", "task") without losing focus.

**Root cause:** `handleKeyForTextArea` used `key.Matches(msg, keys.Common.Down/Up)` for field navigation, but `keys.Common.Down` includes both `"down"` and `"j"` (and `keys.Common.Up` includes both `"up"` and `"k"`). This caused the vim-style navigation keys to be intercepted even in non-vim mode.

**Fix:** Changed to `msg.Type == tea.KeyDown / tea.KeyUp` so only actual arrow key events trigger field navigation. The `j`/`k` characters fall through to the textarea's `Update` handler and are inserted as text.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated documentation as needed
- [x] I have updated golden files if UI changed (`make test-update`)

## Screenshots (if applicable)

N/A

## Testing Notes

1. Open the New Workflow modal (`n` in dashboard mode)
2. Select any template that has a textarea argument field
3. Navigate to the textarea field (Tab or arrow keys)
4. Type a word containing `j` or `k`, e.g. "project" or "task"
5. **Before:** pressing `j`/`k` would move focus to the next/previous field
6. **After:** `j`/`k` are inserted as characters; use arrow keys or Tab to navigate between fields