### PR TITLE
Quit directly with q in kanban/search and strip binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # Version from git (tag or commit hash)
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS := -X 'main.version=$(VERSION)'
+BUILD_LDFLAGS := -s -w $(LDFLAGS)
 
 # Default target
 all: build test
@@ -14,7 +15,7 @@ build-frontend:
 
 # Go-only build (assumes frontend is pre-built)
 build-go:
-	go build -ldflags "$(LDFLAGS)" -o perles .
+	go build -trimpath -ldflags "$(BUILD_LDFLAGS)" -o perles .
 
 build: build-frontend build-go
 
@@ -40,7 +41,7 @@ debug: build-go
 
 # Install the binary to $GOPATH/bin with version info
 install: build-frontend
-	go install -ldflags "$(LDFLAGS)" .
+	go install -trimpath -ldflags "$(BUILD_LDFLAGS)" .
 
 # Run all tests
 test:

--- a/internal/mode/dashboard/model.go
+++ b/internal/mode/dashboard/model.go
@@ -1132,7 +1132,10 @@ func (m Model) handleTableKeys(msg tea.KeyMsg) (mode.Controller, tea.Cmd) {
 		}
 		return m, nil
 
-	case "q", "ctrl+c":
+	case "q":
+		return m, tea.Quit
+
+	case "ctrl+c":
 		return m, func() tea.Msg { return QuitMsg{} }
 	}
 
@@ -1152,7 +1155,10 @@ func (m Model) handleEpicTreeKeys(msg tea.KeyMsg) (mode.Controller, tea.Cmd) {
 	case "ctrl+w": // Toggle coordinator chat panel
 		return m.toggleCoordinatorPanel()
 
-	case "q", "ctrl+c", "esc":
+	case "q":
+		return m, tea.Quit
+
+	case "ctrl+c", "esc":
 		return m, func() tea.Msg { return QuitMsg{} }
 	}
 
@@ -1194,7 +1200,10 @@ func (m Model) handleCoordinatorKeys(msg tea.KeyMsg) (mode.Controller, tea.Cmd) 
 			m.coordinatorPanel.NextTab()
 			return m, nil
 
-		case "q", "ctrl+c":
+		case "q":
+			return m, tea.Quit
+
+		case "ctrl+c":
 			return m, func() tea.Msg { return QuitMsg{} }
 
 		default:
@@ -1232,7 +1241,10 @@ func (m Model) handleCoordinatorKeys(msg tea.KeyMsg) (mode.Controller, tea.Cmd) 
 		}
 		return m, nil
 
-	case "q", "ctrl+c", "esc":
+	case "q":
+		return m, tea.Quit
+
+	case "ctrl+c", "esc":
 		return m, func() tea.Msg { return QuitMsg{} }
 	}
 

--- a/internal/mode/dashboard/model.go
+++ b/internal/mode/dashboard/model.go
@@ -1132,10 +1132,7 @@ func (m Model) handleTableKeys(msg tea.KeyMsg) (mode.Controller, tea.Cmd) {
 		}
 		return m, nil
 
-	case "q":
-		return m, tea.Quit
-
-	case "ctrl+c":
+	case "q", "ctrl+c":
 		return m, func() tea.Msg { return QuitMsg{} }
 	}
 
@@ -1155,10 +1152,7 @@ func (m Model) handleEpicTreeKeys(msg tea.KeyMsg) (mode.Controller, tea.Cmd) {
 	case "ctrl+w": // Toggle coordinator chat panel
 		return m.toggleCoordinatorPanel()
 
-	case "q":
-		return m, tea.Quit
-
-	case "ctrl+c", "esc":
+	case "q", "ctrl+c", "esc":
 		return m, func() tea.Msg { return QuitMsg{} }
 	}
 
@@ -1200,10 +1194,7 @@ func (m Model) handleCoordinatorKeys(msg tea.KeyMsg) (mode.Controller, tea.Cmd) 
 			m.coordinatorPanel.NextTab()
 			return m, nil
 
-		case "q":
-			return m, tea.Quit
-
-		case "ctrl+c":
+		case "q", "ctrl+c":
 			return m, func() tea.Msg { return QuitMsg{} }
 
 		default:
@@ -1241,10 +1232,7 @@ func (m Model) handleCoordinatorKeys(msg tea.KeyMsg) (mode.Controller, tea.Cmd) 
 		}
 		return m, nil
 
-	case "q":
-		return m, tea.Quit
-
-	case "ctrl+c", "esc":
+	case "q", "ctrl+c", "esc":
 		return m, func() tea.Msg { return QuitMsg{} }
 	}
 

--- a/internal/mode/dashboard/model_test.go
+++ b/internal/mode/dashboard/model_test.go
@@ -126,6 +126,37 @@ func TestModel_WorkflowsLoaded_UpdatesState(t *testing.T) {
 	require.Equal(t, controlplane.WorkflowID("wf-2"), m.workflows[1].ID)
 }
 
+func TestModel_QKeyRequestsDashboardExit(t *testing.T) {
+	workflows := []*controlplane.WorkflowInstance{
+		createTestWorkflow("wf-1", "Workflow 1", controlplane.WorkflowRunning),
+	}
+
+	tests := []struct {
+		name  string
+		focus DashboardFocus
+	}{
+		{name: "table", focus: FocusTable},
+		{name: "epic view", focus: FocusEpicView},
+		{name: "coordinator", focus: FocusCoordinator},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, _ := createTestModel(t, workflows)
+			m.focus = tt.focus
+
+			_, cmd := m.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+
+			require.NotNil(t, cmd, "expected dashboard exit command")
+			msg := cmd()
+			_, isTeaQuit := msg.(tea.QuitMsg)
+			require.False(t, isTeaQuit, "q should not quit the app from dashboard")
+			_, isDashboardQuit := msg.(QuitMsg)
+			require.True(t, isDashboardQuit, "expected dashboard QuitMsg")
+		})
+	}
+}
+
 // === Unit Tests: Navigation ===
 
 func TestModel_Navigation_MoveDownIncrementsSelection(t *testing.T) {

--- a/internal/mode/kanban/handlers.go
+++ b/internal/mode/kanban/handlers.go
@@ -40,6 +40,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		switch {
 		case msg.Type == tea.KeyCtrlC:
 			return m, func() tea.Msg { return mode.RequestQuitMsg{} }
+		case key.Matches(msg, keys.Common.Quit):
+			return m, tea.Quit
 		case key.Matches(msg, keys.Common.Escape), key.Matches(msg, keys.Common.Help):
 			m.view = ViewBoard
 			return m, nil
@@ -76,6 +78,9 @@ func (m Model) handleBoardKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	switch {
 	case msg.Type == tea.KeyCtrlC:
 		return m, func() tea.Msg { return mode.RequestQuitMsg{} }
+
+	case key.Matches(msg, keys.Common.Quit):
+		return m, tea.Quit
 
 	case key.Matches(msg, keys.Common.Help):
 		m.view = ViewHelp

--- a/internal/mode/kanban/kanban_test.go
+++ b/internal/mode/kanban/kanban_test.go
@@ -315,22 +315,16 @@ func TestKanban_CtrlC_ReturnsRequestQuitMsg(t *testing.T) {
 	require.True(t, isRequestQuit, "expected mode.RequestQuitMsg")
 }
 
-func TestKanban_QKey_DoesNotQuit(t *testing.T) {
+func TestKanban_QKey_QuitsDirectly(t *testing.T) {
 	m := createTestModel(t)
 	m.view = ViewBoard
 
-	// Simulate 'q' keypress - should NOT quit
 	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
 	_, cmd := m.handleBoardKey(msg)
 
-	// The command should be nil or delegate to board (not tea.Quit or RequestQuitMsg)
-	if cmd != nil {
-		result := cmd()
-		_, isQuit := result.(tea.QuitMsg)
-		require.False(t, isQuit, "expected 'q' key to NOT quit")
-		_, isRequestQuit := result.(mode.RequestQuitMsg)
-		require.False(t, isRequestQuit, "expected 'q' key to NOT request quit")
-	}
+	require.NotNil(t, cmd, "expected quit command")
+	_, isQuit := cmd().(tea.QuitMsg)
+	require.True(t, isQuit, "expected 'q' key to quit directly")
 }
 
 func TestKanban_HelpView_CtrlC_ReturnsRequestQuitMsg(t *testing.T) {

--- a/internal/mode/search/search.go
+++ b/internal/mode/search/search.go
@@ -1023,6 +1023,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	switch m.view {
 	case ViewHelp:
 		switch {
+		case msg.String() == "q":
+			return m, tea.Quit
 		case key.Matches(msg, keys.Common.Escape), key.Matches(msg, keys.Common.Help):
 			m.view = ViewSearch
 		}
@@ -1169,6 +1171,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		switch {
 		case msg.Type == tea.KeyCtrlC:
 			return m, func() tea.Msg { return mode.RequestQuitMsg{} }
+		case msg.String() == "q":
+			return m, tea.Quit
 		case key.Matches(msg, keys.Search.Blur):
 			return m, func() tea.Msg { return ExitToKanbanMsg{} }
 		case key.Matches(msg, keys.Search.Help):
@@ -1258,6 +1262,9 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	switch {
 	case msg.Type == tea.KeyCtrlC:
 		return m, func() tea.Msg { return mode.RequestQuitMsg{} }
+
+	case msg.String() == "q":
+		return m, tea.Quit
 
 	case key.Matches(msg, keys.Search.Blur):
 		// Exit search mode back to kanban

--- a/internal/mode/search/search_test.go
+++ b/internal/mode/search/search_test.go
@@ -1176,22 +1176,16 @@ func TestSearch_CtrlC_ReturnsRequestQuitMsg_TreeSubMode(t *testing.T) {
 	require.True(t, isRequestQuit, "expected mode.RequestQuitMsg in tree sub-mode")
 }
 
-func TestSearch_QKey_DoesNotQuit(t *testing.T) {
+func TestSearch_QKey_QuitsDirectly(t *testing.T) {
 	m := createTestModelWithResults(t)
 	m.focus = FocusResults
 
-	// Simulate 'q' keypress - should NOT quit
 	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
 	_, cmd := m.handleKey(msg)
 
-	// The command should be nil or not a quit-related message
-	if cmd != nil {
-		result := cmd()
-		_, isQuit := result.(tea.QuitMsg)
-		require.False(t, isQuit, "expected 'q' key to NOT quit")
-		_, isRequestQuit := result.(mode.RequestQuitMsg)
-		require.False(t, isRequestQuit, "expected 'q' key to NOT request quit")
-	}
+	require.NotNil(t, cmd, "expected quit command")
+	_, isQuit := cmd().(tea.QuitMsg)
+	require.True(t, isQuit, "expected 'q' key to quit directly")
 }
 
 // =============================================================================

--- a/internal/ui/modals/help/help.go
+++ b/internal/ui/modals/help/help.go
@@ -270,7 +270,7 @@ func (m Model) renderKanbanContent() string {
 	generalCol.WriteString(renderBinding(keys.Common.Help))
 	generalCol.WriteString(renderBinding(keys.Kanban.ToggleStatus))
 	generalCol.WriteString(renderBinding(keys.Kanban.Escape))
-	generalCol.WriteString(renderBinding(keys.Kanban.QuitConfirm))
+	generalCol.WriteString(renderBinding(keys.Common.Quit))
 
 	// User Actions below General (only if user has configured actions)
 	if len(m.userActions) > 0 {
@@ -351,7 +351,7 @@ func (m Model) renderSearchContent() string {
 	generalCol.WriteString("\n")
 	generalCol.WriteString(renderBinding(keys.Search.SwitchMode))
 	generalCol.WriteString(renderBinding(keys.Search.Help))
-	generalCol.WriteString(renderBinding(keys.Search.QuitConfirm))
+	generalCol.WriteString(renderBinding(keys.Common.Quit))
 
 	// User Actions column (only if user has configured actions)
 	var userActionsCol strings.Builder

--- a/internal/ui/modals/help/help_test.go
+++ b/internal/ui/modals/help/help_test.go
@@ -67,7 +67,7 @@ func TestHelp_View_ContainsKeybindings(t *testing.T) {
 
 	// General keys
 	require.Contains(t, view, "?", "expected view to contain help key")
-	require.Contains(t, view, "ctrl+c", "expected view to contain quit key")
+	require.Contains(t, view, "q", "expected view to contain quit key")
 	require.Contains(t, view, "esc", "expected view to contain escape key")
 }
 

--- a/internal/ui/modals/help/testdata/TestHelp_SearchView_Golden.golden
+++ b/internal/ui/modals/help/testdata/TestHelp_SearchView_Golden.golden
@@ -5,7 +5,7 @@
 │  Navigation                   Actions                      General                                          │
 │  h          focus results     enter      open tree view    ctrl+space switch mode                           │
 │  l          focus details     y          copy issue ID     ?          toggle help                           │
-│  k/↑        move up           ctrl+s     save to view      ctrl+c     quit                                  │
+│  k/↑        move up           ctrl+s     save to view      q          quit                                  │
 │  j/↓        move down                                                                                       │
 │  /          focus search                                                                                    │
 │  esc        exit to kanban                                                                                  │

--- a/internal/ui/modals/help/testdata/TestHelp_View_Golden.golden
+++ b/internal/ui/modals/help/testdata/TestHelp_View_Golden.golden
@@ -8,7 +8,7 @@
 │  enter      open tree view       ctrl+j/n   next view        h/l        left/right                 ?          toggle help        │
 │  r          refresh issues       ctrl+k/p   previous view    j/k        up/down                    w          toggle status bar  │
 │  y          copy issue ID        ctrl+v     view menu        ^space     search mode                esc        go back            │
-│  n          new issue            /          search column    ctrl+w     toggle chat panel          ctrl+c     quit               │
+│  n          new issue            /          search column    ctrl+w     toggle chat panel          q          quit               │
 │  a          add column                                       tab        switch chat/board focus                                  │
 │  e          edit column                                      ctrl+j     next chat tab                                            │
 │  d          delete column                                    ctrl+k     prev chat tab                                            │


### PR DESCRIPTION
## Summary
- Make q quit immediately in kanban and search normal views
- Keep dashboard q on the existing dashboard-exit path because workflow persistence is not enabled by default
- Keep Ctrl+C on the existing confirmation/return path
- Strip local build/install binaries with -trimpath and -ldflags "-s -w"

## Verification
- go test ./...
- go test ./internal/mode/dashboard ./internal/app
- git diff --check
- make build-go
- size check: old-style build 61398628 bytes; stripped Makefile build 42598665 bytes
- make lint (blocked: golangci-lint not installed in PATH)